### PR TITLE
Bump version to 0.1.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstrict"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "A lightweight CLI to securely exec Linux processes inside the Kernels Landlock LSM sandbox for filesystem and network access control"
 license = "MIT"


### PR DESCRIPTION
This release incorporates improvements from @lavafroth  which enhances security by adding a pure Rust ELF parser module (ldd.rs) for analyzing binary dependencies. 
This replaces the previous system call to the ldd binary, making the --ldd flag operation more secure by directly parsing ELF binaries and invoking the interpreter when needed.